### PR TITLE
Add text-gray-700 to BaseSelect's options

### DIFF
--- a/www/src/components/BaseSelect.vue
+++ b/www/src/components/BaseSelect.vue
@@ -4,7 +4,7 @@
       class="inline-block text-base w-full m-0 py-2 pl-4 pr-8 leading-normal text-gray-700 bg-white border border-gray-500 rounded cursor-pointer focus:outline-none focus:border-transparent focus:shadow-outline"
       v-bind="$attrs">
         <option
-          class="bg-white"
+          class="bg-white text-gray-700"
           v-for="(option, index) in options"
           :key="index"
           :value="option">{{ option }}


### PR DESCRIPTION
Added `text-gray-700` to the select box options so the bg color and text color don't match.