### PR TITLE
Set flex-shrink default value to 1

### DIFF
--- a/src/components/CssMarkup.vue
+++ b/src/components/CssMarkup.vue
@@ -65,7 +65,7 @@ export default {
             fg = `\n\tflex-grow: ${it.styles.flexGrow};`;
           }
 
-          if (it.styles.flexShrink !== 0) {
+          if (it.styles.flexShrink !== 1) {
             nonDefaultCount++;
             fs = `\n\tflex-shrink: ${it.styles.flexShrink};`;
           }

--- a/src/store.js
+++ b/src/store.js
@@ -45,7 +45,7 @@ export const mutations = {
             styles: {
                 order: 0,
                 flexGrow: 0,
-                flexShrink: 0,
+                flexShrink: 1,
                 flexBasis: 'auto',
                 alignSelf: 'auto'
             }
@@ -98,7 +98,7 @@ export const mutations = {
             it.styles = {
                 order: 0,
                 flexGrow: 0,
-                flexShrink: 0,
+                flexShrink: 1,
                 flexBasis: 'auto',
                 alignSelf: 'auto'
             }


### PR DESCRIPTION
Hello,

I've been using this really cool tool since a while, and I noticed that the `flex-shrink` values are always initialized to `0` but in fact the initial value for this property is `1` as you can see it in the MDN doc [here](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink#formal_definition) or directly in a browser inspector for example.

I didn't sucess to start the project with `npm run dev` but I verified that my code is correct by building and static hosting it 😁